### PR TITLE
Store missing translations as nil values - not empty strings

### DIFF
--- a/example/da.yml
+++ b/example/da.yml
@@ -1,6 +1,6 @@
 ---
 :da:
-  :app_name: ''
+  :app_name:
   :day_names:
   - søndag
   - mandag

--- a/example/en.yml
+++ b/example/en.yml
@@ -1,4 +1,4 @@
 ---
 :en:
-  :app_name: ''
-  :day_names: ''
+  :app_name:
+  :day_names:

--- a/example/session.da.yml
+++ b/example/session.da.yml
@@ -3,7 +3,7 @@
   :session:
     :new:
       :email: ! 'E-mail:'
-      :password: ''
+      :password:
       :login: Log ind
       :remember_me: Husk mig
       :forgot: Har du glemt dit kodeord?

--- a/example/session.en.yml
+++ b/example/session.en.yml
@@ -6,15 +6,15 @@
     :login: Sign in
   :session:
     :new:
-      :email: ''
-      :password: ''
-      :login: ''
+      :email:
+      :password:
+      :login:
       :remember_me: Remember me
       :forgot: Forgotten your password?
-      :v1: ''
+      :v1:
     :create:
       :logged_in: Welcome!
-      :invalid_login: ''
+      :invalid_login:
     :destroy:
-      :logged_out: ''
-      :re_login: ''
+      :logged_out:
+      :re_login:

--- a/lib/i18n_yaml_editor/translation.rb
+++ b/lib/i18n_yaml_editor/translation.rb
@@ -8,6 +8,10 @@ module I18nYamlEditor
       @name, @file, @text = attributes.values_at(:name, :file, :text)
     end
 
+    def text
+      @text == "" ? nil : @text
+    end
+
     def key
       @key ||= self.name.split(".")[1..-1].join(".")
     end

--- a/test/unit/test_store.rb
+++ b/test/unit/test_store.rb
@@ -141,7 +141,8 @@ class TestStore < MiniTest::Unit::TestCase
       },
       "/tmp/da.yml" => {
         da: {
-          app_name: "Oversætter"
+          app_name: "Oversætter",
+          empty_string: nil
         }
       }
     }
@@ -151,6 +152,7 @@ class TestStore < MiniTest::Unit::TestCase
     store.add_translation Translation.new(name: "en.session.login", text: "Sign in", file: "/tmp/session.en.yml")
     store.add_translation Translation.new(name: "da.session.logout", text: "Log ud", file: "/tmp/session.da.yml")
     store.add_translation Translation.new(name: "da.app_name", text: "Oversætter", file: "/tmp/da.yml")
+    store.add_translation Translation.new(name: "da.empty_string", text: "", file: "/tmp/da.yml")
 
     assert_equal expected, store.to_yaml
   end


### PR DESCRIPTION
Storing missing translations as empty strings prevents I18n from using [Fallbacks](https://github.com/svenfuchs/i18n/wiki/Fallbacks)