### PR TITLE
Stringify keys in YAML

### DIFF
--- a/lib/i18n_yaml_editor/transformation.rb
+++ b/lib/i18n_yaml_editor/transformation.rb
@@ -25,9 +25,9 @@ module I18nYamlEditor
           keys = key.split(".")
           keys.each_with_index {|k, idx|
             if keys.size - 1 == idx
-              sub_result[k.to_sym] = value
+              sub_result[k.to_s] = value
             else
-              sub_result = (sub_result[k.to_sym] ||= {})
+              sub_result = (sub_result[k.to_s] ||= {})
             end
           }
         rescue => e


### PR DESCRIPTION
This PR changes the YAML output to use string keys instead of symbol keys.
I think this is a good idea because it is the default in rails and at least the Rubymine editor.
Garbage collection symbols is also not available (yet) to most people.