### PR TITLE
resolve 'exceeded available parameter key space' error

### DIFF
--- a/lib/i18n_yaml_editor/app.rb
+++ b/lib/i18n_yaml_editor/app.rb
@@ -25,6 +25,7 @@ module I18nYamlEditor
       store.create_missing_keys
 
       $stdout.puts " * Starting web editor at port 5050"
+      Rack::Utils.key_space_limit = 131072 # 2 times the default
       Rack::Server.start :app => Web, :Port => 5050
     end
 


### PR DESCRIPTION
In large forms ([like this project](https://github.com/refinery/refinerycms/tree/master/core/config/locales)), I am getting this error on save: `exceeded available parameter key space` by Rack

![2015-10-19_21-46-50](https://cloud.githubusercontent.com/assets/9248917/10587788/84d039ae-76ab-11e5-85bd-6adfb032e06c.png)

So I had to increase the limit for [key_space_limit](https://github.com/rack/rack#key_space_limit) 
