### PR TITLE
Fix yaml parser issue

### DIFF
--- a/lib/i18n_yaml_editor/app.rb
+++ b/lib/i18n_yaml_editor/app.rb
@@ -25,6 +25,7 @@ module I18nYamlEditor
       store.create_missing_keys
 
       $stdout.puts " * Starting web editor at port 5050"
+      Rack::Utils.key_space_limit = 131072 # 2 times the default
       Rack::Server.start :app => Web, :Port => 5050
     end
 

--- a/lib/i18n_yaml_editor/app.rb
+++ b/lib/i18n_yaml_editor/app.rb
@@ -40,7 +40,7 @@ module I18nYamlEditor
     def save_translations
       files = store.to_yaml
       files.each {|file, yaml|
-        File.open(file, "w", encoding: "utf-8") {|f| f << yaml.to_yaml}
+        File.open(file, "w", encoding: "utf-8") {|f| f << yaml.to_yaml({:line_width => -1})}
       }
     end
   end


### PR DESCRIPTION
I was working on [refinerycms](https://github.com/refinery/refinerycms/tree/master/core/config/locales), some values get parsed with new line (`\n`) in it:

``` ruby
h = {"confirm_changes" => "Any changes you've made will be lost. Are you sure you want to continue without saving?"}

#"---\nconfirm_changes: Any changes you've made will be lost. Are you sure you want to continue\n  without saving?\n"
```

https://eval.in/453954

So I had to use `line_width => -1` to solve the problem.
